### PR TITLE
fix(account): construct full image path in OrderHistory for local product images

### DIFF
--- a/components/account/OrderHistory.tsx
+++ b/components/account/OrderHistory.tsx
@@ -69,7 +69,7 @@ export default function OrderHistory() {
                 <div key={item.id} className="flex gap-3 items-center">
                   {item.image ? (
                     <Image
-                      src={item.image}
+                      src={item.image.startsWith("http") || item.image.startsWith("/") ? item.image : `/img/${item.brand}/${item.image}`}
                       alt={item.name}
                       width={56}
                       height={56}


### PR DESCRIPTION
## Summary

Fixes broken product images in the 訂單追蹤 tab. Products store bare filenames (e.g. `SKII1.png`) in the DB; all other product components prepend `/img/${brand}/` to form the full public path. `OrderHistory` was passing the bare filename directly as `src` to `<Image>`, resulting in alt text only.

The fix checks whether `item.image` is already an absolute URL or root-relative path — if not, prepends `/img/${item.brand}/`. This handles both current local images and future Blob/CDN URLs.

Closes #42

## AI Authorship
- [x] AI-authored, human-reviewed
- **Tool**: Claude Sonnet 4.6

## Change classification
- [x] Leaf node — single component, local impact only

## Verification
- Build passes ✅
- Manual: sign in → 訂單追蹤 → product images should now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)